### PR TITLE
fix to use writeFileSync on flushBuffer

### DIFF
--- a/src/large-sort.ts
+++ b/src/large-sort.ts
@@ -342,7 +342,7 @@ function flushBuffer<TValue>(
         let toWrite = mapped.join('\n')
         const filename = path.join(splitPath, `large-sort_${String(linesLoaded).padStart(10, '0')}.txt`);
         outputFiles.push(filename);
-        return new Promise((resolve) => fs.writeFile(filename, toWrite, resolve));
+        fs.writeFileSync(filename, toWrite);
 }
 
 type MergerInfo<T> = {


### PR DESCRIPTION
I encountered an issue with missing data when using `sortStream` with `fs.WriteStream` as the outputStream. Please refer to the logs provided below

```
File written to: /tmp/test/file-82.txt, fileSize: 1019
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_lbA8mJ/large-sort_0000002119.txt, length: 113106, outputfiles count: 1
File written to: /tmp/test/file-83.txt, fileSize: 1019
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_EKe7FS/large-sort_0000002107.txt, length: 112466, outputfiles count: 1
File written to: /tmp/test/file-84.txt, fileSize: 1019
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_suwMJH/large-sort_0000002176.txt, length: 116143, outputfiles count: 1
File written to: /tmp/test/file-85.txt, fileSize: 49705
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_sMcLT3/large-sort_0000002198.txt, length: 117306, outputfiles count: 1
File written to: /tmp/test/file-86.txt, fileSize: 1019
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_6oEbmR/large-sort_0000002138.txt, length: 114120, outputfiles count: 1
File written to: /tmp/test/file-87.txt, fileSize: 1019
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_BoEl6b/large-sort_0000002142.txt, length: 114334, outputfiles count: 1
File written to: /tmp/test/file-88.txt, fileSize: 1019
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_Lsrpas/large-sort_0000002120.txt, length: 113151, outputfiles count: 1
File written to: /tmp/test/file-89.txt, fileSize: 1019
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_nmwRhc/large-sort_0000002104.txt, length: 112308, outputfiles count: 1
File written to: /tmp/test/file-90.txt, fileSize: 48102
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_PMMGAJ/large-sort_0000002115.txt, length: 112887, outputfiles count: 1
File written to: /tmp/test/file-91.txt, fileSize: 1019
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_XEMCgc/large-sort_0000002100.txt, length: 112088, outputfiles count: 1
File written to: /tmp/test/file-92.txt, fileSize: 1019
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_RxvbEZ/large-sort_0000002081.txt, length: 111064, outputfiles count: 1
File written to: /tmp/test/file-93.txt, fileSize: 1019
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_YS5JRf/large-sort_0000002141.txt, length: 114274, outputfiles count: 1
File written to: /tmp/test/file-94.txt, fileSize: 1019
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_cT2jq0/large-sort_0000002184.txt, length: 116568, outputfiles count: 1
File written to: /tmp/test/file-95.txt, fileSize: 49882
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_L9hjXz/large-sort_0000002157.txt, length: 115128, outputfiles count: 1
File written to: /tmp/test/file-96.txt, fileSize: 49279
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_ujtZ72/large-sort_0000002136.txt, length: 114003, outputfiles count: 1
File written to: /tmp/test/file-97.txt, fileSize: 1019
```

I resolved this problem by switching to the `fileWriteSync` method within the `FlushBuffer` function. Please let me know if you have a better method or any suggestions to further improve this solution.

```
File written to: /tmp/test/file-82.txt, fileSize: 48344
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_ZoEGnX/large-sort_0000002097.txt, length: 111928, outputfiles count: 1
File written to: /tmp/test/file-83.txt, fileSize: 47939
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_iQeeXN/large-sort_0000002139.txt, length: 114166, outputfiles count: 1
File written to: /tmp/test/file-84.txt, fileSize: 48875
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_9cUVUW/large-sort_0000002143.txt, length: 114378, outputfiles count: 1
File written to: /tmp/test/file-85.txt, fileSize: 48963
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_tr7ZWJ/large-sort_0000002153.txt, length: 114921, outputfiles count: 1
File written to: /tmp/test/file-86.txt, fileSize: 49196
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_SgX9aC/large-sort_0000002140.txt, length: 114225, outputfiles count: 1
File written to: /tmp/test/file-87.txt, fileSize: 48903
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_nel6iR/large-sort_0000002125.txt, length: 113424, outputfiles count: 1
File written to: /tmp/test/file-88.txt, fileSize: 48567
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_c6YEM3/large-sort_0000002160.txt, length: 115281, outputfiles count: 1
File written to: /tmp/test/file-89.txt, fileSize: 49339
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_GgqKhW/large-sort_0000002129.txt, length: 113637, outputfiles count: 1
File written to: /tmp/test/file-90.txt, fileSize: 48656
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_pnUfw5/large-sort_0000002138.txt, length: 114113, outputfiles count: 1
File written to: /tmp/test/file-91.txt, fileSize: 48853
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_ZwLqNl/large-sort_0000002121.txt, length: 113207, outputfiles count: 1
File written to: /tmp/test/file-92.txt, fileSize: 48474
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_EThgh6/large-sort_0000002142.txt, length: 114337, outputfiles count: 1
File written to: /tmp/test/file-93.txt, fileSize: 48953
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_8A09A6/large-sort_0000002116.txt, length: 112937, outputfiles count: 1
File written to: /tmp/test/file-94.txt, fileSize: 48359
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_U4ToBg/large-sort_0000002101.txt, length: 112143, outputfiles count: 1
File written to: /tmp/test/file-95.txt, fileSize: 48030
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_PeShGi/large-sort_0000002135.txt, length: 113949, outputfiles count: 1
File written to: /tmp/test/file-96.txt, fileSize: 48782
writing file: /var/folders/54/412ymd91387g1vz1xtp09fpm0000gn/T/large-sort/temp_r9V7Qt/large-sort_0000002119.txt, length: 113095, outputfiles count: 1
File written to: /tmp/test/file-97.txt, fileSize: 48424
```
