### PR TITLE
Replace SIGKILL signal handling by SIGTERM and SIGINT

### DIFF
--- a/src/large-sort.ts
+++ b/src/large-sort.ts
@@ -26,7 +26,7 @@ function deleteFiles(tempFolder: string) {
 }
 
 // Doing a best effort to clean any lingering split files
-process.on('SIGKILL', cleanTempFiles);
+process.on('SIGTERM', cleanTempFiles);
 process.on('beforeExit', cleanTempFiles);
 process.on('exit', cleanTempFiles);
 

--- a/src/large-sort.ts
+++ b/src/large-sort.ts
@@ -26,6 +26,7 @@ function deleteFiles(tempFolder: string) {
 }
 
 // Doing a best effort to clean any lingering split files
+process.on('SIGINT', cleanTempFiles);
 process.on('SIGTERM', cleanTempFiles);
 process.on('beforeExit', cleanTempFiles);
 process.on('exit', cleanTempFiles);


### PR DESCRIPTION
Trying to listen for the `SIGKILL` IPC signal results in a  `uv_signal_start EINVAL` error.

According to nodejs documentation on [signal events](https://nodejs.org/docs/latest-v18.x/api/process.html#signal-events):

`'SIGKILL' cannot have a listener installed, it will unconditionally terminate Node.js on all platforms.`

Listening on `SIGINT` (ctrl + c) and `SIGTERM` should be enough to terminate the sort process gracefully.

Thank you for the library it works great once that bug is taken out of the equation.   