### PR TITLE
Bugfix: missing delimiters on multiple stream writes

### DIFF
--- a/lib/large-sort.js
+++ b/lib/large-sort.js
@@ -22,6 +22,15 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.mergeSortedStreams = exports.mergeSortedFiles = exports.merge = exports.sortStream = exports.sortFile = void 0;
 const fs = __importStar(require("fs"));
@@ -36,7 +45,7 @@ function cleanTempFiles() {
         try {
             cleanFn();
         }
-        catch {
+        catch (_a) {
             // Ignore errors
         }
     }
@@ -114,34 +123,36 @@ process.on('exit', cleanTempFiles);
  * @return {Promise<void>}                  - Promise that once resolved the output sorted file has been completely
  *                                            created and the temporary files has been cleaned up.
  */
-async function sortFile(inputFile, outputFile, inputMapFn = x => x, outputMapFn = x => String(x), compareFn = (a, b) => a > b ? 1 : -1, inputDelimeter = '\n', outputDelimeter = '\n', linesPerFile = 100000) {
-    const base = path.join(os.tmpdir(), 'large-sort');
-    if (!fs.existsSync(base)) {
-        fs.mkdirSync(base, { recursive: true });
-    }
-    const tempFolder = fs.mkdtempSync(path.join(base, "temp_"));
-    const tempFiles = new Array();
-    TEMP_SORTS_TO_CLEAN_BEFORE_EXIT.set(tempFolder, () => deleteFiles(tempFolder));
-    try {
-        const inputStream = fs.createReadStream(inputFile, { highWaterMark: Math.pow(2, 20), flags: 'r' });
-        // Wait till the stream is open
-        await new Promise((r) => inputStream.once('open', r));
-        await split(inputStream, tempFolder, tempFiles, inputMapFn, JSON.stringify, compareFn, inputDelimeter, linesPerFile);
-        inputStream.close();
-        const inputBase = path.parse(outputFile).base;
-        const tempBase = inputBase + '.temp';
-        const tempFile = path.join(tempFolder, tempBase);
-        const outputStream = fs.createWriteStream(tempFile, { highWaterMark: Math.pow(2, 23), encoding: "utf-8", flags: 'w' });
-        // Wait till the result stream is open
-        await new Promise((r) => outputStream.once('open', r));
-        await merge(tempFiles, outputStream, JSON.parse, outputMapFn, compareFn, outputDelimeter);
-        outputStream.close();
-        fs.renameSync(tempFile, outputFile);
-    }
-    finally {
-        deleteFiles(tempFolder);
-        TEMP_SORTS_TO_CLEAN_BEFORE_EXIT.delete(tempFolder);
-    }
+function sortFile(inputFile, outputFile, inputMapFn = x => x, outputMapFn = x => String(x), compareFn = (a, b) => a > b ? 1 : -1, inputDelimeter = '\n', outputDelimeter = '\n', linesPerFile = 100000) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const base = path.join(os.tmpdir(), 'large-sort');
+        if (!fs.existsSync(base)) {
+            fs.mkdirSync(base, { recursive: true });
+        }
+        const tempFolder = fs.mkdtempSync(path.join(base, "temp_"));
+        const tempFiles = new Array();
+        TEMP_SORTS_TO_CLEAN_BEFORE_EXIT.set(tempFolder, () => deleteFiles(tempFolder));
+        try {
+            const inputStream = fs.createReadStream(inputFile, { highWaterMark: Math.pow(2, 20), flags: 'r' });
+            // Wait till the stream is open
+            yield new Promise((r) => inputStream.once('open', r));
+            yield split(inputStream, tempFolder, tempFiles, inputMapFn, JSON.stringify, compareFn, inputDelimeter, linesPerFile);
+            inputStream.close();
+            const inputBase = path.parse(outputFile).base;
+            const tempBase = inputBase + '.temp';
+            const tempFile = path.join(tempFolder, tempBase);
+            const outputStream = fs.createWriteStream(tempFile, { highWaterMark: Math.pow(2, 23), encoding: "utf-8", flags: 'w' });
+            // Wait till the result stream is open
+            yield new Promise((r) => outputStream.once('open', r));
+            yield merge(tempFiles, outputStream, JSON.parse, outputMapFn, compareFn, outputDelimeter);
+            outputStream.close();
+            fs.renameSync(tempFile, outputFile);
+        }
+        finally {
+            deleteFiles(tempFolder);
+            TEMP_SORTS_TO_CLEAN_BEFORE_EXIT.delete(tempFolder);
+        }
+    });
 }
 exports.sortFile = sortFile;
 /**
@@ -202,22 +213,24 @@ exports.sortFile = sortFile;
  * @return {Promise<void>}                  - Promise that once resolved the output sorted stream has been completely
  *                                            created and temporary files had been cleaned up.
  */
-async function sortStream(inputStream, outputStream, inputMapFn = x => x, outputMapFn = x => String(x), compareFn = (a, b) => a > b ? 1 : -1, inputDelimeter = '\n', outputDelimeter = '\n', linesPerFile = 100000) {
-    const base = path.join(os.tmpdir(), 'large-sort');
-    if (!fs.existsSync(base)) {
-        fs.mkdirSync(base, { recursive: true });
-    }
-    const tempFolder = fs.mkdtempSync(path.join(base, "temp_"));
-    const tempFiles = new Array();
-    TEMP_SORTS_TO_CLEAN_BEFORE_EXIT.set(tempFolder, () => deleteFiles(tempFolder));
-    try {
-        await split(inputStream, tempFolder, tempFiles, inputMapFn, JSON.stringify, compareFn, inputDelimeter, linesPerFile);
-        await merge(tempFiles, outputStream, JSON.parse, outputMapFn, compareFn, outputDelimeter);
-    }
-    finally {
-        deleteFiles(tempFolder);
-        TEMP_SORTS_TO_CLEAN_BEFORE_EXIT.delete(tempFolder);
-    }
+function sortStream(inputStream, outputStream, inputMapFn = x => x, outputMapFn = x => String(x), compareFn = (a, b) => a > b ? 1 : -1, inputDelimeter = '\n', outputDelimeter = '\n', linesPerFile = 100000) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const base = path.join(os.tmpdir(), 'large-sort');
+        if (!fs.existsSync(base)) {
+            fs.mkdirSync(base, { recursive: true });
+        }
+        const tempFolder = fs.mkdtempSync(path.join(base, "temp_"));
+        const tempFiles = new Array();
+        TEMP_SORTS_TO_CLEAN_BEFORE_EXIT.set(tempFolder, () => deleteFiles(tempFolder));
+        try {
+            yield split(inputStream, tempFolder, tempFiles, inputMapFn, JSON.stringify, compareFn, inputDelimeter, linesPerFile);
+            yield merge(tempFiles, outputStream, JSON.parse, outputMapFn, compareFn, outputDelimeter);
+        }
+        finally {
+            deleteFiles(tempFolder);
+            TEMP_SORTS_TO_CLEAN_BEFORE_EXIT.delete(tempFolder);
+        }
+    });
 }
 exports.sortStream = sortStream;
 /**
@@ -235,72 +248,74 @@ exports.sortStream = sortStream;
  * @return {Promise<void>}                     - Promise that once resolved the output sorted file has been completely
  *                                               created and temporary files has been cleaned up.
  */
-async function split(inputStream, splitPath, outputFiles, inputMapFn, outputMapFn, compareFn, splitDelimeter, linesPerFile) {
-    let linesLoaded = 0;
-    let buffer = [];
-    let previousRemaingData = '';
-    // Memory check variable
-    const MAX_GB = 1;
-    const MAX_BYTES = MAX_GB * 1024 * 1024 * 1024;
-    const baseMemoryUsage = process.memoryUsage();
-    const bytesToMaxBytes = MAX_BYTES - baseMemoryUsage.heapUsed;
-    var current = baseMemoryUsage;
-    var nextMemoryCheck = Math.min(1000, linesPerFile);
-    function shouldFlushMemory(bufferSize) {
-        if (bufferSize !== nextMemoryCheck)
-            return false;
-        current = process.memoryUsage();
-        const heapDiff = current.heapUsed - baseMemoryUsage.heapUsed;
-        const avgBytesPerItem = heapDiff / bufferSize;
-        const maxItems = bytesToMaxBytes / avgBytesPerItem;
-        nextMemoryCheck = Math.floor(maxItems * .50);
-        return current.heapUsed > MAX_BYTES;
-    }
-    const transform = new stream_1.Transform({
-        transform(chunk, encoding, callback) {
-            const buff = chunk;
-            const text = buff.toString();
-            const lines = text.split(splitDelimeter);
-            const end = lines.length - 1;
-            lines[0] = previousRemaingData + lines[0];
-            previousRemaingData = lines[end];
-            for (let i = 0; i < end; i++) {
-                const itemStr = lines[i];
-                try {
-                    const mapped = inputMapFn(itemStr);
-                    buffer.push(mapped);
-                    linesLoaded++;
-                }
-                catch (e) {
-                    console.error("[large-sort] ERROR: Mapping from input file failed. error:" + String(e));
-                }
-                // Check if it needs to flush the buffer becuase of the lines per file or because of memory constrain
-                if (buffer.length === linesPerFile || shouldFlushMemory(buffer.length)) {
-                    flushBuffer(buffer, linesLoaded, splitPath, outputFiles, outputMapFn, compareFn);
-                    buffer.length = 0;
-                }
-            }
-            callback();
-        },
-        flush(callback) {
-            if (previousRemaingData.trim() != '') {
-                try {
-                    const mapped = inputMapFn(previousRemaingData);
-                    buffer.push(mapped);
-                }
-                catch (e) {
-                    console.error("[large-sort] ERROR: Mapping from input file failed. error:" + String(e));
-                }
-            }
-            // Process the last buffer if needed
-            if (buffer.length !== 0) {
-                flushBuffer(buffer, linesLoaded, splitPath, outputFiles, outputMapFn, compareFn);
-            }
-            callback();
+function split(inputStream, splitPath, outputFiles, inputMapFn, outputMapFn, compareFn, splitDelimeter, linesPerFile) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let linesLoaded = 0;
+        let buffer = [];
+        let previousRemaingData = '';
+        // Memory check variable
+        const MAX_GB = 1;
+        const MAX_BYTES = MAX_GB * 1024 * 1024 * 1024;
+        const baseMemoryUsage = process.memoryUsage();
+        const bytesToMaxBytes = MAX_BYTES - baseMemoryUsage.heapUsed;
+        var current = baseMemoryUsage;
+        var nextMemoryCheck = Math.min(1000, linesPerFile);
+        function shouldFlushMemory(bufferSize) {
+            if (bufferSize !== nextMemoryCheck)
+                return false;
+            current = process.memoryUsage();
+            const heapDiff = current.heapUsed - baseMemoryUsage.heapUsed;
+            const avgBytesPerItem = heapDiff / bufferSize;
+            const maxItems = bytesToMaxBytes / avgBytesPerItem;
+            nextMemoryCheck = Math.floor(maxItems * .50);
+            return current.heapUsed > MAX_BYTES;
         }
-    });
-    await new Promise((resolve, reject) => {
-        (0, stream_1.pipeline)(inputStream, transform, (err) => err ? reject(err) : resolve());
+        const transform = new stream_1.Transform({
+            transform(chunk, encoding, callback) {
+                const buff = chunk;
+                const text = buff.toString();
+                const lines = text.split(splitDelimeter);
+                const end = lines.length - 1;
+                lines[0] = previousRemaingData + lines[0];
+                previousRemaingData = lines[end];
+                for (let i = 0; i < end; i++) {
+                    const itemStr = lines[i];
+                    try {
+                        const mapped = inputMapFn(itemStr);
+                        buffer.push(mapped);
+                        linesLoaded++;
+                    }
+                    catch (e) {
+                        console.error("[large-sort] ERROR: Mapping from input file failed. error:" + String(e));
+                    }
+                    // Check if it needs to flush the buffer becuase of the lines per file or because of memory constrain
+                    if (buffer.length === linesPerFile || shouldFlushMemory(buffer.length)) {
+                        flushBuffer(buffer, linesLoaded, splitPath, outputFiles, outputMapFn, compareFn);
+                        buffer.length = 0;
+                    }
+                }
+                callback();
+            },
+            flush(callback) {
+                if (previousRemaingData.trim() != '') {
+                    try {
+                        const mapped = inputMapFn(previousRemaingData);
+                        buffer.push(mapped);
+                    }
+                    catch (e) {
+                        console.error("[large-sort] ERROR: Mapping from input file failed. error:" + String(e));
+                    }
+                }
+                // Process the last buffer if needed
+                if (buffer.length !== 0) {
+                    flushBuffer(buffer, linesLoaded, splitPath, outputFiles, outputMapFn, compareFn);
+                }
+                callback();
+            }
+        });
+        yield new Promise((resolve, reject) => {
+            (0, stream_1.pipeline)(inputStream, transform, (err) => err ? reject(err) : resolve());
+        });
     });
 }
 /**
@@ -338,17 +353,19 @@ function flushBuffer(buffer, linesLoaded, splitPath, outputFiles, outputMapFn, c
  *                                                    See: {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#parameters}
  * @param {string}                  outputDelimeter - String delimeter to separate each output string after been mapped to
  */
-async function merge(inputs, outputStream, inputMapFn = x => x, outputMapFn = x => String(x), compareFn = (a, b) => a > b ? 1 : -1, outputDelimeter = '\n') {
-    if (!inputs || inputs.length === 0)
-        return;
-    if (inputs[0] instanceof stream_1.Readable) {
-        const streams = inputs;
-        await mergeSortedStreams(streams, outputStream, inputMapFn, outputMapFn, compareFn, outputDelimeter);
-    }
-    else {
-        const files = inputs;
-        await mergeSortedFiles(files, outputStream, inputMapFn, outputMapFn, compareFn, outputDelimeter);
-    }
+function merge(inputs, outputStream, inputMapFn = x => x, outputMapFn = x => String(x), compareFn = (a, b) => a > b ? 1 : -1, outputDelimeter = '\n') {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (!inputs || inputs.length === 0)
+            return;
+        if (inputs[0] instanceof stream_1.Readable) {
+            const streams = inputs;
+            yield mergeSortedStreams(streams, outputStream, inputMapFn, outputMapFn, compareFn, outputDelimeter);
+        }
+        else {
+            const files = inputs;
+            yield mergeSortedFiles(files, outputStream, inputMapFn, outputMapFn, compareFn, outputDelimeter);
+        }
+    });
 }
 exports.merge = merge;
 /**
@@ -367,24 +384,26 @@ exports.merge = merge;
  *                                            See: {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#parameters}
  * @param {string}          outputDelimeter - String delimeter to separate each output string after been mapped to
  */
-async function mergeSortedFiles(files, outputStream, inputMapFn, outputMapFn, compareFn, outputDelimeter) {
-    if (files.length === 0)
-        return;
-    const streams = [];
-    for (let i = 0; i < files.length; i++) {
-        const f = files[i];
-        const stream = fs.createReadStream(f, { highWaterMark: 100000, flags: 'r' });
-        streams.push(stream);
-    }
-    try {
-        await mergeSortedStreams(streams, outputStream, inputMapFn, outputMapFn, compareFn, outputDelimeter);
-    }
-    finally {
-        for (let i = 0; i < streams.length; i++) {
-            const stream = streams[i];
-            stream.close();
+function mergeSortedFiles(files, outputStream, inputMapFn, outputMapFn, compareFn, outputDelimeter) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (files.length === 0)
+            return;
+        const streams = [];
+        for (let i = 0; i < files.length; i++) {
+            const f = files[i];
+            const stream = fs.createReadStream(f, { highWaterMark: 100000, flags: 'r' });
+            streams.push(stream);
         }
-    }
+        try {
+            yield mergeSortedStreams(streams, outputStream, inputMapFn, outputMapFn, compareFn, outputDelimeter);
+        }
+        finally {
+            for (let i = 0; i < streams.length; i++) {
+                const stream = streams[i];
+                stream.close();
+            }
+        }
+    });
 }
 exports.mergeSortedFiles = mergeSortedFiles;
 /**
@@ -403,110 +422,128 @@ exports.mergeSortedFiles = mergeSortedFiles;
  *                                            See: {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#parameters}
  * @param {string}          outputDelimeter - String delimeter to separate each output string after been mapped to
  */
-async function mergeSortedStreams(streams, outputStream, inputMapFn, outputMapFn, compareFn, outputDelimeter) {
-    // Nothing to merge exit right away.
-    if (streams.length === 0)
-        return;
-    let readers = new Array();
-    // Create readers
-    for (const readStream of streams) {
-        const reader = readline.createInterface({
-            input: readStream,
-            crlfDelay: Infinity
-        });
-        const iterator = reader[Symbol.asyncIterator]();
-        const firstNext = await iterator.next();
-        if (firstNext.done) {
-            reader.close();
-            continue;
+function mergeSortedStreams(streams, outputStream, inputMapFn, outputMapFn, compareFn, outputDelimeter) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // Nothing to merge exit right away.
+        if (streams.length === 0)
+            return;
+        let readers = new Array();
+        // Create readers
+        for (const readStream of streams) {
+            const reader = readline.createInterface({
+                input: readStream,
+                crlfDelay: Infinity
+            });
+            const iterator = reader[Symbol.asyncIterator]();
+            const firstNext = yield iterator.next();
+            if (firstNext.done) {
+                reader.close();
+                continue;
+            }
+            readers.push({
+                data: inputMapFn(firstNext.value),
+                iter: iterator,
+                reader: reader,
+                readStream: readStream
+            });
         }
-        readers.push({
-            data: inputMapFn(firstNext.value),
-            iter: iterator,
-            reader: reader,
-            readStream: readStream
-        });
-    }
-    // Reverse sort based on the to do the merge
-    let mergerInfoReverseCompareFn = (a, b) => compareFn(b.data, a.data);
-    readers.sort(mergerInfoReverseCompareFn);
-    var resultStream = outputStream;
-    let writeBuffer = new Array();
-    let previousPromise = Promise.resolve();
-    let bufferStringSize = 0;
-    const maxStringLength = Math.pow(2, 23) * .90; // 90% of the node js string max length
-    // Using index to avoid the (array.length - 1) operations
-    let lastReaderIdx = readers.length - 1;
-    let beforeLastReaderIdx = readers.length - 2;
-    // Looping till there is only one left
-    while (readers.length !== 1) {
-        const mergerInfo = readers[lastReaderIdx];
-        let dataStr = outputMapFn(mergerInfo.data);
-        bufferStringSize += dataStr.length;
-        if (bufferStringSize > maxStringLength) {
-            writeBuffer.push('');
-            let bufferStr = writeBuffer.join(outputDelimeter);
-            writeBuffer = [];
-            bufferStringSize = dataStr.length;
-            await previousPromise;
-            previousPromise = new Promise((res) => resultStream.write(bufferStr, () => res()));
-        }
-        writeBuffer.push(dataStr);
-        let next;
-        next = await mergerInfo.iter.next();
-        if (next.done) {
-            // Cleaning mergeInfo once the reader is done.
-            mergerInfo.reader.close();
-            readers.pop();
-            lastReaderIdx--;
-            beforeLastReaderIdx--;
-        }
-        else {
-            // Map the object to the output
-            mergerInfo.data = inputMapFn(next.value);
-            // Checking if it needs to be re-index the merge info if the previous is more than itself
-            const previous = readers[beforeLastReaderIdx];
-            if (mergerInfoReverseCompareFn(mergerInfo, previous) < 0) {
+        // Reverse sort based on the to do the merge
+        let mergerInfoReverseCompareFn = (a, b) => compareFn(b.data, a.data);
+        readers.sort(mergerInfoReverseCompareFn);
+        var resultStream = outputStream;
+        let writeBuffer = new Array();
+        let previousPromise = Promise.resolve();
+        let bufferStringSize = 0;
+        const maxStringLength = Math.pow(2, 23) * .90; // 90% of the node js string max length
+        // Using index to avoid the (array.length - 1) operations
+        let lastReaderIdx = readers.length - 1;
+        let beforeLastReaderIdx = readers.length - 2;
+        // Looping till there is only one left
+        while (readers.length !== 1) {
+            const mergerInfo = readers[lastReaderIdx];
+            let dataStr = outputMapFn(mergerInfo.data);
+            bufferStringSize += dataStr.length;
+            if (bufferStringSize > maxStringLength) {
+                writeBuffer.push('');
+                let bufferStr = writeBuffer.join(outputDelimeter);
+                // Add a delimeter if there isn't already one
+                if (!bufferStr.endsWith(outputDelimeter)) {
+                    bufferStr += outputDelimeter;
+                }
+                writeBuffer = [];
+                bufferStringSize = dataStr.length;
+                yield previousPromise;
+                previousPromise = new Promise((res) => resultStream.write(bufferStr, () => res()));
+            }
+            writeBuffer.push(dataStr);
+            let next;
+            next = yield mergerInfo.iter.next();
+            if (next.done) {
+                // Cleaning mergeInfo once the reader is done.
+                mergerInfo.reader.close();
                 readers.pop();
-                let insertIdx = binarySearch(mergerInfo, readers, mergerInfoReverseCompareFn);
-                readers.splice(insertIdx, 0, mergerInfo);
+                lastReaderIdx--;
+                beforeLastReaderIdx--;
+            }
+            else {
+                // Map the object to the output
+                mergerInfo.data = inputMapFn(next.value);
+                // Checking if it needs to be re-index the merge info if the previous is more than itself
+                const previous = readers[beforeLastReaderIdx];
+                if (mergerInfoReverseCompareFn(mergerInfo, previous) < 0) {
+                    readers.pop();
+                    let insertIdx = binarySearch(mergerInfo, readers, mergerInfoReverseCompareFn);
+                    readers.splice(insertIdx, 0, mergerInfo);
+                }
             }
         }
-    }
-    // Taking care of the last remaining stream
-    const lastMergeInfo = readers[0];
-    let next = await lastMergeInfo.iter.next();
-    const lastMergeInfoDataOutput = outputMapFn(lastMergeInfo.data);
-    bufferStringSize += lastMergeInfoDataOutput.length;
-    if (bufferStringSize > maxStringLength) {
-        const toWrite = writeBuffer.join(outputDelimeter);
-        await previousPromise;
-        previousPromise = new Promise((resolve) => resultStream.write(toWrite, () => resolve()));
-        bufferStringSize = lastMergeInfoDataOutput.length;
-        writeBuffer = [];
-    }
-    writeBuffer.push(lastMergeInfoDataOutput);
-    while (!next.done) {
-        const input = inputMapFn(next.value);
-        const output = outputMapFn(input);
-        bufferStringSize += output.length;
+        // Taking care of the last remaining stream
+        const lastMergeInfo = readers[0];
+        let next = yield lastMergeInfo.iter.next();
+        const lastMergeInfoDataOutput = outputMapFn(lastMergeInfo.data);
+        bufferStringSize += lastMergeInfoDataOutput.length;
         if (bufferStringSize > maxStringLength) {
-            // Flush buffer
-            const toWrite = writeBuffer.join(outputDelimeter);
-            await previousPromise;
+            let toWrite = writeBuffer.join(outputDelimeter);
+            // Add a delimeter if there isn't already one
+            if (!toWrite.endsWith(outputDelimeter)) {
+                toWrite += outputDelimeter;
+            }
+            yield previousPromise;
             previousPromise = new Promise((resolve) => resultStream.write(toWrite, () => resolve()));
-            bufferStringSize = output.length;
+            bufferStringSize = lastMergeInfoDataOutput.length;
             writeBuffer = [];
         }
-        writeBuffer.push(output);
-        next = await lastMergeInfo.iter.next();
-    }
-    lastMergeInfo.reader.close();
-    // Flushing the last buffer
-    const toWrite = writeBuffer.join(outputDelimeter);
-    // Wait for the previous promise
-    await previousPromise;
-    await new Promise((resolve) => resultStream.write(toWrite, () => resolve()));
+        writeBuffer.push(lastMergeInfoDataOutput);
+        while (!next.done) {
+            const input = inputMapFn(next.value);
+            const output = outputMapFn(input);
+            bufferStringSize += output.length;
+            if (bufferStringSize > maxStringLength) {
+                // Flush buffer
+                let toWrite = writeBuffer.join(outputDelimeter);
+                // Add a delimeter if there isn't already one
+                if (!toWrite.endsWith(outputDelimeter)) {
+                    toWrite += outputDelimeter;
+                }
+                yield previousPromise;
+                previousPromise = new Promise((resolve) => resultStream.write(toWrite, () => resolve()));
+                bufferStringSize = output.length;
+                writeBuffer = [];
+            }
+            writeBuffer.push(output);
+            next = yield lastMergeInfo.iter.next();
+        }
+        lastMergeInfo.reader.close();
+        // Flushing the last buffer
+        let toWrite = writeBuffer.join(outputDelimeter);
+        // Add a delimeter if there isn't already one
+        if (!toWrite.endsWith(outputDelimeter)) {
+            toWrite += outputDelimeter;
+        }
+        // Wait for the previous promise
+        yield previousPromise;
+        yield new Promise((resolve) => resultStream.write(toWrite, () => resolve()));
+    });
 }
 exports.mergeSortedStreams = mergeSortedStreams;
 function binarySearch(target, array, compareFn) {

--- a/src/large-sort.ts
+++ b/src/large-sort.ts
@@ -494,7 +494,7 @@ export async function mergeSortedStreams<TValue>(
             bufferStringSize += dataStr.length;
             if(bufferStringSize > maxStringLength) {
                 writeBuffer.push('')
-                let bufferStr = writeBuffer.join(outputDelimeter);
+                let bufferStr = writeBuffer.join(outputDelimeter) + outputDelimeter;
                 writeBuffer = [];
                 bufferStringSize = dataStr.length;
                 await previousPromise;
@@ -534,7 +534,7 @@ export async function mergeSortedStreams<TValue>(
 
         bufferStringSize += lastMergeInfoDataOutput.length;
         if(bufferStringSize > maxStringLength) {
-            const toWrite = writeBuffer.join(outputDelimeter);
+            const toWrite = writeBuffer.join(outputDelimeter) + outputDelimeter;
             await previousPromise;
             previousPromise = new Promise<void>((resolve) => resultStream.write(toWrite, () => resolve()));
             bufferStringSize = lastMergeInfoDataOutput.length;
@@ -547,7 +547,7 @@ export async function mergeSortedStreams<TValue>(
             bufferStringSize += output.length;
             if(bufferStringSize > maxStringLength) {
                 // Flush buffer
-                const toWrite = writeBuffer.join(outputDelimeter);
+                const toWrite = writeBuffer.join(outputDelimeter) + outputDelimeter;
                 await previousPromise;
                 previousPromise = new Promise<void>((resolve) => resultStream.write(toWrite, () => resolve()));
                 bufferStringSize = output.length;
@@ -560,7 +560,7 @@ export async function mergeSortedStreams<TValue>(
         lastMergeInfo.reader.close();
 
         // Flushing the last buffer
-        const toWrite = writeBuffer.join(outputDelimeter)
+        const toWrite = writeBuffer.join(outputDelimeter) + outputDelimeter
         // Wait for the previous promise
         await previousPromise;
         await new Promise<void>((resolve) => resultStream.write(toWrite, () => resolve()));

--- a/src/large-sort.ts
+++ b/src/large-sort.ts
@@ -494,7 +494,13 @@ export async function mergeSortedStreams<TValue>(
             bufferStringSize += dataStr.length;
             if(bufferStringSize > maxStringLength) {
                 writeBuffer.push('')
-                let bufferStr = writeBuffer.join(outputDelimeter) + outputDelimeter;
+                let bufferStr = writeBuffer.join(outputDelimeter);
+
+                // Add a delimeter if there isn't already one
+                if (!bufferStr.endsWith(outputDelimeter)){
+                    bufferStr += outputDelimeter;
+                }
+
                 writeBuffer = [];
                 bufferStringSize = dataStr.length;
                 await previousPromise;
@@ -534,7 +540,13 @@ export async function mergeSortedStreams<TValue>(
 
         bufferStringSize += lastMergeInfoDataOutput.length;
         if(bufferStringSize > maxStringLength) {
-            const toWrite = writeBuffer.join(outputDelimeter) + outputDelimeter;
+            let toWrite = writeBuffer.join(outputDelimeter);
+
+            // Add a delimeter if there isn't already one
+            if (!toWrite.endsWith(outputDelimeter)){
+                toWrite += outputDelimeter;
+            }
+
             await previousPromise;
             previousPromise = new Promise<void>((resolve) => resultStream.write(toWrite, () => resolve()));
             bufferStringSize = lastMergeInfoDataOutput.length;
@@ -547,7 +559,13 @@ export async function mergeSortedStreams<TValue>(
             bufferStringSize += output.length;
             if(bufferStringSize > maxStringLength) {
                 // Flush buffer
-                const toWrite = writeBuffer.join(outputDelimeter) + outputDelimeter;
+                let toWrite = writeBuffer.join(outputDelimeter);
+                
+                // Add a delimeter if there isn't already one
+                if (!toWrite.endsWith(outputDelimeter)){
+                    toWrite += outputDelimeter;
+                }
+                
                 await previousPromise;
                 previousPromise = new Promise<void>((resolve) => resultStream.write(toWrite, () => resolve()));
                 bufferStringSize = output.length;

--- a/src/large-sort.ts
+++ b/src/large-sort.ts
@@ -578,7 +578,13 @@ export async function mergeSortedStreams<TValue>(
         lastMergeInfo.reader.close();
 
         // Flushing the last buffer
-        const toWrite = writeBuffer.join(outputDelimeter) + outputDelimeter
+        let toWrite = writeBuffer.join(outputDelimeter);
+
+        // Add a delimeter if there isn't already one
+        if (!toWrite.endsWith(outputDelimeter)){
+            toWrite += outputDelimeter;
+        }
+
         // Wait for the previous promise
         await previousPromise;
         await new Promise<void>((resolve) => resultStream.write(toWrite, () => resolve()));


### PR DESCRIPTION
On large files, each subsequent call to resultStream.write would cause two lines to be written on the same line in the sorted output.  

This proposed solution is a very basic change to add an outputDelimeter to the end of the string before being written to the stream.

This does result in an additional newline at the end of the file.  However, this newline exists in my original unsorted file and was previously lost.

One other note, initially I wasn't able to recreate the issue with sample data generated in excel on windows... This was due to the extra \r from Windows.  

Test data attached, sort on the first column.  On my machine there were four combined lines from this dataset.
[large_sort_test.zip](https://github.com/nelson-perez/large-sort/files/13835849/large_sort_test.zip)
